### PR TITLE
Fix systemd service

### DIFF
--- a/radiodawg.py
+++ b/radiodawg.py
@@ -9,12 +9,10 @@ MIN_DROPPED_PACKETS = 2
 
 def stop_playback():
     print("Stopping Volumio playback...")
-    sys.stdout.flush()
     os.system("volumio stop")
 
 def start_playback():
     print("Starting Volumio playback...")
-    sys.stdout.flush()
     os.system("volumio play")
 
 def is_net_reachable():
@@ -50,14 +48,11 @@ while True:
         if is_connection_down():
             print(DNS_TO_QUERY + " is not reachable (" + str(MIN_DROPPED_PACKETS) 
                     + " subsequently dropped packets), stopping Volumio playback")
-            sys.stdout.flush()
             stop_playback()
             while not is_net_reachable():
                 print(DNS_TO_QUERY + " is still not reachable, trying again in " + str(TIMEOUT_SEC) + " sec")
-                sys.stdout.flush()
                 time.sleep(TIMEOUT_SEC)
             print(DNS_TO_QUERY + " is reachable again, resuming Volumio playback now")
-            sys.stdout.flush()
             start_playback()
 
     time.sleep(TIMEOUT_SEC)

--- a/radiodawg.service
+++ b/radiodawg.service
@@ -1,11 +1,12 @@
+[Unit]
 Description=run radiodawg Python script at startup
 After=network.target
-After=local-fs-pre.target
+After=syslog.target
 
 [Service]
-Type=oneshot
+Type=simple
 User=root
-ExecStart=/usr/bin/python /usr/bin/radiodawg.py
+ExecStart=/usr/bin/python -u /usr/bin/radiodawg.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix/improve systemd service & adapt Python script.

- Make radiodawg a type simple systemd service (instead of oneshot)
- Replace _After=local-fs-pre.target_ with _syslog.target_ for guaranteed monitorability via systemctl
- Make the service run the Python script in unbuffered output mode
- Remove obsolete stdout flushes in the Python script
