### PR TITLE
introduce playback status check incl. constant

### DIFF
--- a/radiodawg.py
+++ b/radiodawg.py
@@ -6,6 +6,7 @@ TIMEOUT_SEC = 1
 DNS_TO_QUERY = "8.8.8.8"
 MUTE = " > /dev/null 2>&1"
 MIN_DROPPED_PACKETS = 2
+CONSIDER_PLAYBACK_STATUS = True
 
 def stop_playback():
     print("Stopping Volumio playback...")
@@ -39,8 +40,11 @@ def is_connection_down():
                 dropped_packets += 1
 
 def is_streaming_webradio():
-    response = os.system("volumio status | grep webradio" + MUTE)
-    if response is 0:
+    is_in_playback_state = os.system("volumio status | grep play" + MUTE)
+    if CONSIDER_PLAYBACK_STATUS and not is_in_playback_state is 0:
+        return False
+    is_type_webradio = os.system("volumio status | grep webradio" + MUTE)
+    if is_type_webradio is 0:
         return True
     else:
         return False


### PR DESCRIPTION
Introducing a constant CONSIDER_PLAYBACK_STATUS (set _True_ per default), the script will only resume playback of webstreams if Volumio had been in a playback state before the connection drop-out.

Setting the constant to _False_ will "aggressively" start streaming if there is e.g. a webradio at the current playlist's head as soon as the default DNS becomes reachable again.